### PR TITLE
Allow impersonating users with empty passwords

### DIFF
--- a/src/Storage/SessionStorage.php
+++ b/src/Storage/SessionStorage.php
@@ -74,7 +74,7 @@ class SessionStorage
      * @param  string $password
      * @return void
      */
-    public function setPasswordHash(string $password) : void
+    public function setPasswordHash(?string $password) : void
     {
         session()->put([
             'password_hash_sanctum' => $password,


### PR DESCRIPTION
Users might not have a password set when logging in using a different method than a password login, like OTP. 
When impersonating, the current flow always expects a password. This would make impersonating this set of users impossible. 
By making the password optional, all users could be impersonated.